### PR TITLE
Licence Connect: Doku für Lizenzhalter und Lizenznutzer hinzugefügt

### DIFF
--- a/docs/licence-connect/index.md
+++ b/docs/licence-connect/index.md
@@ -1,5 +1,4 @@
 ---
-sidebar_position: 1
 title: "Licence Connect"
 ---
 
@@ -21,4 +20,4 @@ Der gesamt Code ist Open Source verfügbar unter: https://github.com/FWU-DE/lice
 ## API Spezifikation
 
 Die aktuelle API von Licence Connect ist als OpenAPI Spezifikation unter [/api/licence-connect](/api/licence-connect) dokumentiert.
-Eine interaktive SwaggerUI ist hier verfügbar: https://api.licenceconnect.schule/swagger-ui/index.html.
+Eine interaktive SwaggerUI ist hier verfügbar: https://api.licenceconnect.schule/swagger.

--- a/docs/licence-connect/lizenzhalter.md
+++ b/docs/licence-connect/lizenzhalter.md
@@ -3,8 +3,6 @@ sidebar_position: 2
 title: "Für Lizenzhalter"
 ---
 
-## Für Lizenzhaltende Systeme
-
 Um als lizenzhaltendes System Lizenzinformationen über Licence Connect zur Verfügung zu stellen, ist eine Anbindung an Licence Connect erforderlich.
 
 Lizenzinformationen werden abhängig von:

--- a/docs/licence-connect/lizenzhalter.md
+++ b/docs/licence-connect/lizenzhalter.md
@@ -1,0 +1,28 @@
+---
+sidebar_position: 2
+title: "Für Lizenzhalter"
+---
+
+## Für Lizenzhaltende Systeme
+
+Um als lizenzhaltendes System Lizenzinformationen über Licence Connect zur Verfügung zu stellen, ist eine Anbindung an Licence Connect erforderlich.
+
+Lizenzinformationen werden abhängig von:
+
+* userId des Users im Ländersystem
+* Bundesland
+* Standortnummer
+* Schulnummer
+
+abgerufen.
+
+Zur Weiterleitung an Lizenznutzer müssen die Lizenzinformationen in das ODRL-Format übersetzt werden.
+Das Mapping kann Teil von Licence Connect sein und im Rahmen der Anbindung durchgeführt werden.
+
+### Referenz
+
+Als Referenz-Implementierung wurde "LC Halt" implementiert.
+Unter https://halt.licenceconnect.schule/docs sind die API-Schnittstellen von "LC Halt" dokumentiert.
+
+Für die Anbindung an Licence Connect ist insbesondere der Endpunkt "/licenced-media" relevant.
+

--- a/docs/licence-connect/lizenznutzer.md
+++ b/docs/licence-connect/lizenznutzer.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 1
+title: "Für Lizenznutzer"
+---
+
+## Für Lizenznutzende Systeme
+
+Lizenzinformationen aus Licence Connect können über VIDIS abgerufen werden.
+Aktuell ist das mit der erforderlichen Konfiguration im Staging-System möglich.
+
+### Lizenzen Abrufen
+
+Lizenzen können im VIDIS-Staging-System unter
+
+```
+https://aai-test.vidis.schule/auth/realms/vidis/licences/<pseudonym>
+```
+
+abgerufen werden.
+Zur Authentifizierung ist der Access Token von VIDIS notwendig.
+Das Pseudonym ist die User ID in VIDIS (`sub`-Value im Token).
+
+Ein valider cURL Request sieht wie folgt aus:
+
+```
+ACCESS_TOKEN="<access_token>"
+SUB="<sub>"
+
+curl -v "https://aai-test.vidis.schule/auth/realms/vidis/licences/$SUB" \
+     -H "Authorization: Bearer $ACCESS_TOKEN"
+```
+
+### Antwortformat
+
+Die Lizenzdaten werden im ODRL-Format übertragen.
+Eine detaillierte Beschreibung findet sich in der OpenAPI Spezifikation unter https://api.licenceconnect.schule/swagger-ui/index.html#/licences-controller/request_1

--- a/docs/licence-connect/lizenznutzer.md
+++ b/docs/licence-connect/lizenznutzer.md
@@ -3,8 +3,6 @@ sidebar_position: 1
 title: "Für Lizenznutzer"
 ---
 
-## Für Lizenznutzende Systeme
-
 Lizenzinformationen aus Licence Connect können über VIDIS abgerufen werden.
 Aktuell ist das mit der erforderlichen Konfiguration im Staging-System möglich.
 


### PR DESCRIPTION
Mit dieser Dokumentation sollen Lizenznutzern und Lizenzhaltern erste Anhaltspunkte für die Anbindung an Licence Connect gegeben werden. Bei Bedarf kann diese Dokumentation angepasst und vertieft werden, um synchrone Abstimmungen im Rahmen einer Anbindung zu minimieren.